### PR TITLE
Added support for Sec-WebSocket-Protocol

### DIFF
--- a/WebSockets/WebSocketServer/WebSocketServer.cs
+++ b/WebSockets/WebSocketServer/WebSocketServer.cs
@@ -150,6 +150,7 @@ namespace System.Net.WebSockets.Server
             var headerConnection = context.Request.Headers["Connection"];
             var headerUpgrade = context.Request.Headers["Upgrade"];
             var headerSwk = context.Request.Headers["Sec-WebSocket-Key"];
+            var headerSecProtocol = context.Request.Headers["Sec-WebSocket-Protocol"];
             WebSocketContext websocketContext = context.GetWebsocketContext();
 
             if (headerConnection == "Upgrade" && headerUpgrade == "websocket" && !string.IsNullOrEmpty(headerSwk))
@@ -166,7 +167,7 @@ namespace System.Net.WebSockets.Server
                 string swka = swk + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"; //default signature for websocket
                 byte[] swkaSha1 = WebSocketHelpers.ComputeHash(swka);
                 string swkaSha1Base64 = Convert.ToBase64String(swkaSha1);
-                byte[] response = Encoding.UTF8.GetBytes($"HTTP/1.1 101 Web Socket Protocol Handshake\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {swkaSha1Base64}\r\nServer: {ServerName}\r\nUpgrade: websocket\r\n\r\n");
+                byte[] response = Encoding.UTF8.GetBytes($"HTTP/1.1 101 Web Socket Protocol Handshake\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {swkaSha1Base64}\r\nServer: {ServerName}\r\nUpgrade: websocket{(!string.IsNullOrEmpty(headerSecProtocol)? "\r\nSec-WebSocket-Protocol: " + headerSecProtocol : "")}\r\n\r\n");
                 websocketContext.NetworkStream.Write(response, 0, response.Length);
 
                 var webSocketClient = new WebSocketServerClient(_options);


### PR DESCRIPTION
<!--- In the TITLE (above **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
Sec-WebSocket-Protocol Websocket Header is now being echoed back to client. When used in handshake it needs to be echoed back to client, if it's suported by server. The implementation does not support any extra protcol, but the user can implement this by checking this header themself.  
<!--- Bulleted list. Full sentences. Ending with a dot. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For proprietary use of the Sec-WebSocket-Protocol header. Not having this means the handshake will fail and is socket is disconnected 
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
Using a browser and websocket client ran multiple tests. 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
