### PR TITLE
Added support for custom Http Headers for Websocket

### DIFF
--- a/WebSockets.Client/System.Net.WebSockets.Client.nfproj
+++ b/WebSockets.Client/System.Net.WebSockets.Client.nfproj
@@ -38,6 +38,9 @@
     </Compile>
     <Compile Include="..\WebSockets\ClientWebSocket\ClientWebSocketOptions.cs">
       <Link>ClientWebSocket\ClientWebSocketOptions.cs</Link>
+	</Compile>
+    <Compile Include="..\WebSockets\ClientWebSocket\ClientWebSocketHeaders.cs">
+      <Link>ClientWebSocket\ClientWebSocketHeaders.cs</Link>
     </Compile>
     <Compile Include="..\WebSockets\MessageReceivedEventArgs.cs">
       <Link>MessageReceivedEventArgs.cs</Link>

--- a/WebSockets/ClientWebSocket/ClientWebSocketHeaders.cs
+++ b/WebSockets/ClientWebSocket/ClientWebSocketHeaders.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections;
+using System.Text;
+
+namespace System.Net.WebSockets
+{
+    /// <summary>
+    /// A Dictionary to store custom Http Headers to use with the ClientWebsocket
+    /// </summary>
+    public class ClientWebSocketHeaders
+    {
+        private Hashtable _headers = new Hashtable();
+
+        /// <summary>
+        /// Gets the number of headers.
+        /// </summary>
+        public int Count { get { return _headers.Count; } }
+
+        /// <summary>
+        /// Gets all header keys.
+        /// </summary>
+        public string[] Keys { get { return GetKeys(); } }
+
+        /// <summary>
+        /// Gets all header values.
+        /// </summary>
+        public string[] Values { get { return GetValues(); } }
+
+        /// <summary>
+        /// Gets a value header or Sets a header value
+        /// </summary>
+        public string this[string key]
+        {
+            get
+            {
+                return _headers[key] as string;
+            }
+            set
+            {
+
+                _headers[key] = value;
+                
+            }
+        }
+
+        /// <summary>
+        /// Removes a header from the dictionary
+        /// </summary>
+        public void Remove(string value)
+        {
+            _headers.Remove(value);
+            
+        }
+
+        private string[] GetKeys()
+        {
+            var keys = _headers.Keys;
+            string[] returnkeys = new string[keys.Count];
+
+            int i = 0;
+            foreach (object key in keys)
+            {
+                returnkeys[i] = key as string;
+                i++;
+            }
+
+            return returnkeys;
+        }
+
+        private string[] GetValues()
+        {
+            var values = _headers.Values;
+            string[] returnkeys = new string[values.Count];
+
+            int i = 0;
+            foreach (object value in values)
+            {
+                returnkeys[i] = value as string;
+                i++;
+            }
+
+            return returnkeys;
+        }
+    }
+}

--- a/WebSockets/System.Net.WebSockets.nfproj
+++ b/WebSockets/System.Net.WebSockets.nfproj
@@ -33,6 +33,7 @@
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
+    <Compile Include="ClientWebSocket\ClientWebSocketHeaders.cs" />
     <Compile Include="MessageReceivedEventArgs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="WebSocket.cs" />

--- a/WebSockets/WebSocket.cs
+++ b/WebSockets/WebSocket.cs
@@ -302,9 +302,15 @@ namespace System.Net.WebSockets
             ConnectionClosed?.Invoke(this, new EventArgs());
 
             //Let the tcp socket linger for a second so it can try and send all data out before final close. 
-            _socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Linger, 1); 
-            
-            _socket.Close();
+            try
+            {
+                _socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Linger, 1);
+                _socket.Close();
+            }
+            catch (ObjectDisposedException e)
+            {
+                Debug.WriteLine("socket could not be closed properly because it was already disposed");
+            }
         }
 
         internal bool QueueMessageToSend(SendMessageFrame frame)

--- a/WebSockets/WebSocketServer/WebSocketServer.cs
+++ b/WebSockets/WebSocketServer/WebSocketServer.cs
@@ -150,6 +150,7 @@ namespace System.Net.WebSockets.Server
             var headerConnection = context.Request.Headers["Connection"];
             var headerUpgrade = context.Request.Headers["Upgrade"];
             var headerSwk = context.Request.Headers["Sec-WebSocket-Key"];
+            var headerSecProtocol = context.Request.Headers["Sec-WebSocket-Protocol"];
             WebSocketContext websocketContext = context.GetWebsocketContext();
 
             if (headerConnection == "Upgrade" && headerUpgrade == "websocket" && !string.IsNullOrEmpty(headerSwk))
@@ -166,7 +167,7 @@ namespace System.Net.WebSockets.Server
                 string swka = swk + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"; //default signature for websocket
                 byte[] swkaSha1 = WebSocketHelpers.ComputeHash(swka);
                 string swkaSha1Base64 = Convert.ToBase64String(swkaSha1);
-                byte[] response = Encoding.UTF8.GetBytes($"HTTP/1.1 101 Web Socket Protocol Handshake\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {swkaSha1Base64}\r\nServer: {ServerName}\r\nUpgrade: websocket\r\n\r\n");
+                byte[] response = Encoding.UTF8.GetBytes($"HTTP/1.1 101 Web Socket Protocol Handshake\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {swkaSha1Base64}\r\nServer: {ServerName}\r\nUpgrade: websocket{(!string.IsNullOrEmpty(headerSecProtocol)? "\r\nSec-WebSocket-Protocol: " + headerSecProtocol : "")}\r\n\r\n");
                 websocketContext.NetworkStream.Write(response, 0, response.Length);
 
                 var webSocketClient = new WebSocketServerClient(_options);


### PR DESCRIPTION
<!--- In the TITLE (above **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
Option for adding custom headers to the Websockets.Client
small fix of bug when trying to close websocket that's already disposed (racing conditions) objectdisposedExpetion 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
You can now have extra control over custom headers. This can be used for authentication or other things. This makes the Client more usable. 
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
With websocket server and NF websocket Client.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
