### PR TITLE
Default SSL protocol for Client WebSocketOptions is now TLS1.2

### DIFF
--- a/WebSockets/ClientWebSocket/ClientWebSocketOptions.cs
+++ b/WebSockets/ClientWebSocket/ClientWebSocketOptions.cs
@@ -18,12 +18,12 @@ namespace System.Net.WebSockets
         /// Gets or sets the TLS/SSL protocol used by the <see cref="WebSocket"/> class.
         /// </summary>
         /// <value>
-        /// One of the values defined in the <see cref="SslProtocols"/> enumeration.
+        /// One of the values defined in the <see cref="SslProtocols"/> enumeration. Default is <see cref="SslProtocols.Tls12"/>.
         /// </value>
         /// <remarks>
-        /// This property is specific to nanoFramework. There is no equivalent in the .NET API.
+        /// This property is specific to .NET nanoFramework. There is no equivalent in the .NET API.
         /// </remarks>
-        public SslProtocols SslProtocol { get; set; }
+        public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls12;
 
         /// <summary>
         /// Option for SSL verification.


### PR DESCRIPTION
## Description
- Default SSL protocol for Client WebSocketOptions is now TLS1.2.

## Motivation and Context
- Having it as None is troublesome as it forces it to always be set. Defaulting it to 1.2 seems a reasonable option.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
