### PR TITLE
Read Headers line by line until an empty line is found

### DIFF
--- a/WebSockets/ClientWebSocket/ClientWebSocket.cs
+++ b/WebSockets/ClientWebSocket/ClientWebSocket.cs
@@ -297,6 +297,18 @@ namespace System.Net.WebSockets
             byte[] buffer = new byte[200];
             int index = 0;
 
+            void Append(int i)
+            {
+                buffer[index++] = (byte)i;
+                
+                if (index >= buffer.Length)
+                {
+                    var newBuffer = new byte[buffer.Length * 2];
+                    buffer.CopyTo(newBuffer, 0);
+                    buffer = newBuffer;
+                }
+            }
+            
             int b;
             while ((b = _networkStream.ReadByte()) != -1)
             {
@@ -307,21 +319,10 @@ namespace System.Net.WebSockets
                     {
                         return Encoding.UTF8.GetString(buffer, 0, index);
                     }
-                    buffer[index++] = (byte)'\r';
-                    if (index >= buffer.Length)
-                    {
-                        var newBuffer = new byte[buffer.Length * 2];
-                        buffer.CopyTo(newBuffer, 0);
-                        buffer = newBuffer;
-                    }
+                    Append('\r');
                 }
-                buffer[index++] = (byte)b;
-                if (index >= buffer.Length)
-                {
-                    var newBuffer = new byte[buffer.Length * 2];
-                    buffer.CopyTo(newBuffer, 0);
-                    buffer = newBuffer;
-                }
+
+                Append(b);
             }
 
             return null;

--- a/WebSockets/ClientWebSocket/ClientWebSocket.cs
+++ b/WebSockets/ClientWebSocket/ClientWebSocket.cs
@@ -3,7 +3,9 @@
 // See LICENSE file in the project root for full license information.
 //
 
+using System.Collections;
 using System.Diagnostics;
+using System.IO;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Net.WebSockets.WebSocketFrame;
@@ -238,7 +240,6 @@ namespace System.Net.WebSockets
 
             string beginHeader = ($"HTTP/1.1 101".ToLower());
             byte[] bufferStart = new byte[beginHeader.Length];
-            byte[] buffer = new byte[600];
 
             int bytesRead = _networkStream.Read(bufferStart, 0, bufferStart.Length);
 
@@ -246,23 +247,19 @@ namespace System.Net.WebSockets
 
             if (bytesRead == bufferStart.Length)
             {
-                if (Encoding.UTF8.GetString(bufferStart, 0, bufferStart.Length).ToLower() == beginHeader)
+                if (Encoding.UTF8.GetString(bufferStart, 0, bytesRead).ToLower() == beginHeader)
                 {
+                    IDictionary headers = ReadHeaders();
+
                     //right http request
-                    bytesRead = _networkStream.Read(buffer, 0, buffer.Length);
+                    string swka = swk + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+                    byte[] swkaSha1 = WebSocketHelpers.ComputeHash(swka);
+                    string swkaSha1Base64 = Convert.ToBase64String(swkaSha1);
 
-                    if (bytesRead > 20)
+                    if (((string)headers["connection"]).ToLower() == "upgrade" && ((string)headers["upgrade"]).ToLower() == "websocket" && (string)headers["sec-websocket-accept"] == swkaSha1Base64)
                     {
-                        var headers = WebSocketHelpers.ParseHeaders(Encoding.UTF8.GetString(buffer, 0, bytesRead));
-                        string swka = swk + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
-                        byte[] swkaSha1 = WebSocketHelpers.ComputeHash(swka);
-                        string swkaSha1Base64 = Convert.ToBase64String(swkaSha1);
-
-                        if (((string)headers["connection"]).ToLower() == "upgrade" && ((string)headers["upgrade"]).ToLower() == "websocket" && (string)headers["sec-websocket-accept"] == swkaSha1Base64)
-                        {
-                            Debug.WriteLine("WebSocket Client connected");
-                            correctHandshake = true;
-                        }
+                        Debug.WriteLine("WebSocket Client connected");
+                        correctHandshake = true;
                     }
                 }
             }
@@ -276,9 +273,58 @@ namespace System.Net.WebSockets
             }
 
             ConnectToStream(_networkStream, false, _tcpSocket);
+        }
 
+        private IDictionary ReadHeaders()
+        {
+            IDictionary headers = new Hashtable();
 
+            string header;
+            while (!string.IsNullOrEmpty(header = ReadLine()))
+            {
+                var keyVal = header.Split(':');
+                if (keyVal.Length == 2)
+                {
+                    headers[keyVal[0].Trim().ToLower()] = keyVal[1].Trim();
+                }
+            }
 
+            return headers;
+        }
+
+        private string ReadLine()
+        {
+            byte[] buffer = new byte[200];
+            int index = 0;
+
+            int b;
+            while ((b = _networkStream.ReadByte()) != -1)
+            {
+                if (b == '\r')
+                {
+                    b = _networkStream.ReadByte();
+                    if (b == '\n')
+                    {
+                        return Encoding.UTF8.GetString(buffer, 0, index);
+                    }
+                    buffer[index++] = (byte)'\r';
+                    if (index >= buffer.Length)
+                    {
+                        var newBuffer = new byte[buffer.Length * 2];
+                        buffer.CopyTo(newBuffer, 0);
+                        buffer = newBuffer;
+                    }
+                }
+                buffer[index++] = (byte)b;
+                if (index >= buffer.Length)
+                {
+                    var newBuffer = new byte[buffer.Length * 2];
+                    buffer.CopyTo(newBuffer, 0);
+                    buffer = newBuffer;
+                }
+            }
+
+            return null;
         }
 
         /// <inheritdoc/>

--- a/WebSockets/WebSocket.cs
+++ b/WebSockets/WebSocket.cs
@@ -138,10 +138,10 @@ namespace System.Net.WebSockets
             WebSocketReceiver = new WebSocketReceiver(stream, RemoteEndPoint, this, IsServer, MaxReceiveFrameSize, OnReadError);
             _webSocketSender = new WebSocketSender(stream, IsServer, OnWriteError);
 
+            State = WebSocketState.Open;
+
             ReceiveAndControllThread receiveThread = new ReceiveAndControllThread(this);
             new Thread(receiveThread.WorkerThread).Start();
-
-            State = WebSocketState.Open;
         }
 
         /// <summary>

--- a/WebSockets/WebSocketHelpers.cs
+++ b/WebSockets/WebSocketHelpers.cs
@@ -21,22 +21,6 @@ namespace System.Net.WebSockets
             return returnBytes;
         }
 
-        public static IDictionary ParseHeaders(string handshake)
-        {
-            var headers = handshake.Split(new char[] { '\r', '\n' });
-            IDictionary dic = new Hashtable();
-            foreach (string header in headers)
-            {
-                var keyVal = header.Split(':');
-                if (keyVal.Length == 2)
-                {
-                    dic[keyVal[0].Trim().ToLower()] = keyVal[1].Trim();
-                }
-            }
-
-            return dic;
-        }
-
         private static uint SHA1RotateLeft(uint x, int n)
         {
             return ((x << n) | (x >> (32 - n)));


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
- Fix for issue where pasing if the headers also consumes the data of the first message if available. Now we only read the headers line by line and stop reading after the first blank line (CRLFCRLF) so the first message will still be available for processing later on.
- Also, because a message can now be available immediately, the MessageReceived callback could be called directly, so we need to set the State to 'Connected' before starting the ReceiveAndControllThread Thread. Otherwise inside the callback the State is still 'Connecting' and we cannot send messages from it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Fixes nanoFramework/Home#1356.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


I tested this for my own use case which connects to Home Assistant. Home Assistant sends a first message directly after connecting, which caused the original issue. Other scenario's I have not tested

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
