### PR TITLE
Allow headers on ClientWebSocket to accept both `\n` and `\r+\n`

### DIFF
--- a/WebSockets/ClientWebSocket/ClientWebSocket.cs
+++ b/WebSockets/ClientWebSocket/ClientWebSocket.cs
@@ -159,7 +159,7 @@ namespace System.Net.WebSockets
                     }
                     catch (Exception ex)
                     {
-                        throw new Exception("Something is wrong with the port number of the websocket url");
+                        throw new Exception($"Something is wrong with the port number of the websocket url: {ex.Message}.");
                     }
                 }
             }
@@ -169,8 +169,6 @@ namespace System.Net.WebSockets
 
             byte[] buffer = new byte[1024];
             _tcpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-
-            NetworkStream stream = null;
 
             try
             {

--- a/WebSockets/ClientWebSocket/ClientWebSocket.cs
+++ b/WebSockets/ClientWebSocket/ClientWebSocket.cs
@@ -308,13 +308,17 @@ namespace System.Net.WebSockets
                     buffer = newBuffer;
                 }
             }
-            
+
             int b;
             while ((b = _networkStream.ReadByte()) != -1)
             {
-                if (b == '\r')
+                if (b == '\r' || b == '\n')
                 {
-                    b = _networkStream.ReadByte();
+                    if (b == '\r')
+                    {
+                        b = _networkStream.ReadByte();
+                    }
+
                     if (b == '\n')
                     {
                         return Encoding.UTF8.GetString(buffer, 0, index);

--- a/WebSockets/WebSocket.cs
+++ b/WebSockets/WebSocket.cs
@@ -309,7 +309,7 @@ namespace System.Net.WebSockets
             }
             catch (ObjectDisposedException e)
             {
-                Debug.WriteLine("socket could not be closed properly because it was already disposed");
+                Debug.WriteLine($"Socket could not be closed properly because it was already disposed: {e.Message}.");
             }
         }
 

--- a/WebSockets/WebSocketServer/WebSocketServer.cs
+++ b/WebSockets/WebSocketServer/WebSocketServer.cs
@@ -142,7 +142,7 @@ namespace System.Net.WebSockets.Server
         /// Add a websocket client to the Websocket.
         /// After this the HttpListnerContext should be discarded!
         ///</summary>
-        ///<param name="context"> The HttpListnerContext
+        ///<param name="context"> The HttpListnerContext </param>
         public bool AddWebSocket(HttpListenerContext context)
         {
             //TODO check for limit number of clients. 


### PR DESCRIPTION
## Description
Code on websocket handshake would only work with headers being sent with a \r\n and not just a \n.  This has been changed to accept both.
General clean up on compile warnings.

## Motivation and Context
Spent hours trying to figure out why the code would not work with an example websocket server until I finally figured out the issue.  I could not see in the websocket RFC that \n was not acceptable (instead of the \r\n.  Might help with linux websocket server implementations.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
I pulled this code and used the project with my application.  Once I found the issue, I modified the code to make sure the connections now worked with either \r\n or \n.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
